### PR TITLE
fix(redmine): Handle required fields

### DIFF
--- a/sentry_redmine/plugin.py
+++ b/sentry_redmine/plugin.py
@@ -217,18 +217,12 @@ class RedminePlugin(IssuePlugin):
     def validate_config(self, project, config, actor):
         super(RedminePlugin, self).validate_config(project, config, actor)
         self.client_errors = []
-        required_fields = ['project_id', 'tracker_id', 'default_priority']
-        index = [2, 3, 4]
-        
-        try:
-            for field in required_fields:
-                for i in index:
-                    if self.fields[i]['name'] == field:
-                        if config[field] == None or config[field] == '':
-                            self.logger.exception(six.text_type('{} required.'.format(field)))
-                            self.client_errors.append(field)
-        except IndexError:
-            pass
+
+        for field in self.fields:
+            if field['name'] in ['project_id', 'tracker_id', 'default_priority']:
+                if not config[field['name']]:
+                    self.logger.exception(six.text_type('{} required.'.format(field['name'])))
+                    self.client_errors.append(field['name'])
 
         if self.client_errors:
             raise PluginError(', '.join(self.client_errors) + ' required.')


### PR DESCRIPTION
Handle the required fields project_id, tracker_id, and default_priority after Host and Key credentials have been added.

## Before

Even when Host/Key was saved, the other required fields (Project, Tracker, and Default Priority) would not populate with the required information in order to continue:
<img width="471" alt="screen shot 2018-07-03 at 2 46 36 am" src="https://user-images.githubusercontent.com/20312973/42212745-dca4d304-7e6b-11e8-8d92-e146f055b00a.png">

## After

Enter Host/Key > Save:
<img width="543" alt="screen shot 2018-07-03 at 1 10 41 am" src="https://user-images.githubusercontent.com/20312973/42212951-6222d31e-7e6c-11e8-8890-4a619f94db94.png">

Continue to connect/Save your Project, Tracker, Default Priority, and any Extra Fields:
<img width="434" alt="screen shot 2018-07-03 at 1 12 44 am" src="https://user-images.githubusercontent.com/20312973/42213080-bb5f6500-7e6c-11e8-88f4-c9a3c04a3cc3.png">

Error messages added:
<img width="432" alt="screen shot 2018-07-03 at 1 11 58 am" src="https://user-images.githubusercontent.com/20312973/42213130-d8bb95a6-7e6c-11e8-94ac-2827505a341c.png">