### PR TITLE
Fixed pip install command in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Install
 
 Install the package via ``pip``::
 
-    pip install sentry-redmine
+    pip install git+git://github.com/getsentry/sentry-redmine@master
 
 Configuration
 -------------


### PR DESCRIPTION
It might be worth contacting the publisher on pip https://pypi.org/user/aaditya/ to transfer ownership of the package so you can distribute your updated version of it.

I can confirm that the plugin works in Sentry 9.0.0 even when installed with the Docker onbuild image. https://github.com/getsentry/docker-sentry/tree/master/9.0/onbuild